### PR TITLE
Remove leading '_' from generated functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,9 @@ script:
   - bazel build //...
   - bazel test //...
 
+after_failure:
+  - cat bazel-testlogs/**/*.log # Print test log on failure.
+
+
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ that can be used to validate your incoming data.
 
 ```javascript
 // @@START_GENERATED_FUNCTIONS@@
-function is_PersonMessage(resource) {
+function isPersonMessage(resource) {
   return ((resource.keys().hasAll(['name']) && resource.size() == 1)) ||
           (resource.keys().hasAll(['name','email']) && resource.size() == 2)) ||
           (resource.keys().hasAll(['name','phone']) && resource.size() == 2)) ||
@@ -57,7 +57,7 @@ function is_PersonMessage(resource) {
           ((resource.email == null) || (resource.email is string)) &&
           ((resource.phone == null) || (is_Person_PhoneNumberMessage(resource.phone)));
 }
-function is_Person_PhoneNumberMessage(resource) {
+function isPerson_PhoneNumberMessage(resource) {
   return ((resource.keys().hasAll([]) && resource.size() == 0)) ||
           (resource.keys().hasAll(['number']) && resource.size() == 1)) ||
           (resource.keys().hasAll(['type']) && resource.size() == 1)) ||
@@ -65,7 +65,7 @@ function is_Person_PhoneNumberMessage(resource) {
           ((resource.number == null) || (resource.number is string)) &&
           ((resource.type == null) || (is_Person_PhoneTypeEnum(resource.type)));
 }
-function is_Person_PhoneTypeEnum(resource) {
+function isPerson_PhoneTypeEnum(resource) {
   return resource == "MOBILE" ||
           resource == "HOME" ||
           resource == "WORK";

--- a/firebase_rules_generator/generator.cc
+++ b/firebase_rules_generator/generator.cc
@@ -33,21 +33,23 @@ namespace {
 
 struct RulesContext {};
 
-std::string SanitizeName(std::string name) {
-  for (size_t i = 0; i < name.size(); ++i) {
-    if (name[i] == '.') {
-      name[i] = '_';
-    }
-  }
-  return name;
-}
-
-std::string StripPrefix(std::string str, const std::string &prefix) {
+std::string StripPrefix(const std::string &str, const std::string &prefix) {
   if (prefix.size() <= str.size() && str.substr(0, prefix.size()) == prefix) {
     return str.substr(prefix.size());
   } else {
     return str;
   }
+}
+
+std::string SanitizeName(const std::string &name) {
+  // Strip leading '.' characters.
+  std::string sanitized_name = StripPrefix(name, ".");
+  for (size_t i = 0; i < sanitized_name.size(); ++i) {
+    if (sanitized_name[i] == '.') {
+      sanitized_name[i] = '_';
+    }
+  }
+  return sanitized_name;
 }
 
 void ReturnIndent(protobuf::io::Printer &printer) {

--- a/testdata/test0.rules
+++ b/testdata/test0.rules
@@ -1,5 +1,5 @@
 // @@START_GENERATED_FUNCTIONS@@
-function is_ExampleMessage(resource) {
+function isExampleMessage(resource) {
   return ((resource.keys().hasAll([]) && resource.size() == 0)) ||
           (resource.keys().hasAll(['foo']) && resource.size() == 1)) ||
           (resource.keys().hasAll(['bar']) && resource.size() == 1)) ||

--- a/testdata/test1.rules
+++ b/testdata/test1.rules
@@ -1,5 +1,5 @@
 // @@START_GENERATED_FUNCTIONS@@
-function is_ExampleMessage(resource) {
+function isExampleMessage(resource) {
   return ((resource.keys().hasAll(['foo']) && resource.size() == 1)) ||
           (resource.keys().hasAll(['foo','bar']) && resource.size() == 2)) ||
           (resource.keys().hasAll(['foo','baz']) && resource.size() == 2)) ||

--- a/testdata/test3.rules
+++ b/testdata/test3.rules
@@ -1,10 +1,10 @@
 // @@START_GENERATED_FUNCTIONS@@
-function is_ExampleWithStringsEnum(resource) {
+function isExampleWithStringsEnum(resource) {
   return resource == "FOO" ||
           resource == "BAR" ||
           resource == "BAZ";
 }
-function is_ExampleWithNumbersEnum(resource) {
+function isExampleWithNumbersEnum(resource) {
   return resource == 0 ||
           resource == 1 ||
           resource == 2;

--- a/testdata/test4.rules
+++ b/testdata/test4.rules
@@ -1,5 +1,5 @@
 // @@START_GENERATED_FUNCTIONS@@
-function is_ExampleMessage(resource) {
+function isExampleMessage(resource) {
   return ((resource.keys().hasAll([]) && resource.size() == 0)) ||
           (resource.keys().hasAll(['foo']) && resource.size() == 1)) ||
           (resource.keys().hasAll(['bar']) && resource.size() == 1)) ||

--- a/testdata/test5.rules
+++ b/testdata/test5.rules
@@ -1,22 +1,22 @@
 // @@START_GENERATED_FUNCTIONS@@
-function is_PersonMessage(resource) {
+function isPersonMessage(resource) {
   return ((resource.keys().hasAll(['name']) && resource.size() == 1)) ||
           (resource.keys().hasAll(['name','email']) && resource.size() == 2)) ||
           (resource.keys().hasAll(['name','phone']) && resource.size() == 2)) ||
           (resource.keys().hasAll(['name','phone','email']) && resource.size() == 3))) &&
           ((resource.name is string)) &&
           ((resource.email == null) || (resource.email is string)) &&
-          ((resource.phone == null) || (is_Person_PhoneNumberMessage(resource.phone)));
+          ((resource.phone == null) || (isPerson_PhoneNumberMessage(resource.phone)));
 }
-function is_Person_PhoneNumberMessage(resource) {
+function isPerson_PhoneNumberMessage(resource) {
   return ((resource.keys().hasAll([]) && resource.size() == 0)) ||
           (resource.keys().hasAll(['number']) && resource.size() == 1)) ||
           (resource.keys().hasAll(['type']) && resource.size() == 1)) ||
           (resource.keys().hasAll(['type','number']) && resource.size() == 2))) &&
           ((resource.number == null) || (resource.number is string)) &&
-          ((resource.type == null) || (is_Person_PhoneTypeEnum(resource.type)));
+          ((resource.type == null) || (isPerson_PhoneTypeEnum(resource.type)));
 }
-function is_Person_PhoneTypeEnum(resource) {
+function isPerson_PhoneTypeEnum(resource) {
   return resource == "MOBILE" ||
           resource == "HOME" ||
           resource == "WORK";

--- a/testdata/test7.rules
+++ b/testdata/test7.rules
@@ -1,5 +1,5 @@
 // @@START_GENERATED_FUNCTIONS@@
-function is_ExampleMessage(resource) {
+function isExampleMessage(resource) {
   return ((resource.keys().hasAll([]) && resource.size() == 0)) ||
           (resource.keys().hasAll(['foo']) && resource.size() == 1)) ||
           (resource.keys().hasAll(['bar']) && resource.size() == 1)) ||


### PR DESCRIPTION
When stripping the package name off the message and enum names, there
was a `'.'` character still before the message name.